### PR TITLE
Specify NIP-09 ride deletion, make reader honor it (issue #38)

### DIFF
--- a/nostr/README.md
+++ b/nostr/README.md
@@ -50,8 +50,44 @@ Use the following Nostr-specific tags that make interacting with the Nostr event
 | `d`           | String (UUID recommended)     | Yes   | Unique identifier for the specific ride. Prevents duplicates, enables updates/deletion. By posting a new event with the same d tag its content can be changed - the older version of the event may be discarded by relays. Each application posting hitchhiking events can come up with their own schema, it is recommended to use "`source`-`version 4 UUID`". |
 | `g`           | String (Geohash Prefix)| Yes       | Cascading **origin** geohash (at least of length 10) for area filtering. This means there will be multiple g tags, one for each precision level that the geohash provides. Has to be equivalent to the loaction of the first `stop` object in the `stops` field in `content` (the starting location). |
 | `published_at`           | String (UNIX timestamp) | Yes       | The timestamp (in unix seconds – converted to string) of the first version of this ride that was published as a Nostr event. If a `source` application directly posts events to Nostr this is equivalent to the time in `submission_time` field in `content`. If the ride was recorded well before it was published as a Nostr event, then `submission_time` must be earlier than `published_at`. Note: this tag cannot be filtered by as it is not a single letter. |
-| `expiration`           | int| No       | If you are still testing and playing around with Nostr events set this to `0`. Otherwise this tag is not needed. |
+| `expiration`           | String (UNIX timestamp) | No | [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) timestamp after which a temporary event should expire. `0` is already expired and relays may drop the event immediately. This is useful for test events, but it is not a ride-deletion signal. |
 
+
+# How to delete a ride
+
+Publish a [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md)
+kind-5 deletion request signed by the same key that signed the ride. Reference
+the ride by its address (`kind`, author public key, and `d` value), not by
+publishing an already-expired replacement:
+
+```json
+{
+  "kind": 5,
+  "content": "published by mistake",
+  "tags": [
+    ["a", "36820:<ride-author-pubkey>:<ride-d-tag>"],
+    ["e", "<current-ride-event-id>"],
+    ["k", "36820"]
+  ],
+  "pubkey": "<same-pubkey-as-the-ride>"
+}
+```
+
+The `a` tag is required by this standard. It addresses every version of the
+kind-36820 ride up to the deletion request's `created_at`; the `e` tag for the
+current event ID is recommended for compatibility with consumers that index
+deletions by event ID. The `k` tag declares the referenced event kind. Sign and
+publish the deletion request to every relay where the ride was published.
+
+Consumers must fetch kind-5 events as well as kind 36820. Hide a ride only when
+the deletion request's `pubkey` equals the ride author's public key (and, for an
+`a` tag, the public key inside the address). Apply an address deletion only to
+versions whose `created_at` is not later than the deletion request. Keep the
+deletion request or an equivalent tombstone so a later full import cannot
+restore a deleted ride.
+
+A deletion request cannot guarantee erasure from every relay or client that
+has already copied the event. Applications should say this plainly to users.
 
 # How does a hitchhiking ride look like as a Nostr event?
 

--- a/nostr/fetch_hitchhiking_events/package.json
+++ b/nostr/fetch_hitchhiking_events/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "npm run build && node --test dist/deletions.test.js"
   },
   "keywords": [],
   "author": "",

--- a/nostr/fetch_hitchhiking_events/src/deletions.test.ts
+++ b/nostr/fetch_hitchhiking_events/src/deletions.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isDeletedBy, NostrEvent } from "./deletions.js";
+
+const ride = (overrides: Partial<NostrEvent> = {}): NostrEvent => ({
+    id: "ride-event-id",
+    pubkey: "author-pubkey",
+    created_at: 100,
+    kind: 36820,
+    tags: [["d", "source-ride:with-colon"]],
+    ...overrides,
+});
+
+const deletion = (overrides: Partial<NostrEvent> = {}): NostrEvent => ({
+    id: "deletion-event-id",
+    pubkey: "author-pubkey",
+    created_at: 200,
+    kind: 5,
+    tags: [["a", "36820:author-pubkey:source-ride:with-colon"], ["k", "36820"]],
+    ...overrides,
+});
+
+test("an author can delete every older version by ride address", () => {
+    assert.equal(isDeletedBy(ride(), deletion()), true);
+});
+
+test("an e tag deletes the exact event for compatibility", () => {
+    assert.equal(
+        isDeletedBy(ride(), deletion({ tags: [["e", "ride-event-id"], ["k", "36820"]] })),
+        true,
+    );
+});
+
+test("an e tag identifies the exact event despite author clock skew", () => {
+    assert.equal(
+        isDeletedBy(
+            ride(),
+            deletion({ created_at: 90, tags: [["e", "ride-event-id"]] }),
+        ),
+        true,
+    );
+});
+
+test("another author cannot delete the ride", () => {
+    assert.equal(isDeletedBy(ride(), deletion({ pubkey: "attacker-pubkey" })), false);
+});
+
+test("an address containing another author cannot delete the ride", () => {
+    assert.equal(
+        isDeletedBy(
+            ride(),
+            deletion({ tags: [["a", "36820:attacker-pubkey:source-ride:with-colon"]] }),
+        ),
+        false,
+    );
+});
+
+test("a later republished version survives an older deletion request", () => {
+    assert.equal(isDeletedBy(ride({ created_at: 300 }), deletion()), false);
+});
+
+test("an unrelated event id is not deleted", () => {
+    assert.equal(
+        isDeletedBy(ride(), deletion({ tags: [["e", "different-event-id"]] })),
+        false,
+    );
+});

--- a/nostr/fetch_hitchhiking_events/src/deletions.ts
+++ b/nostr/fetch_hitchhiking_events/src/deletions.ts
@@ -1,0 +1,43 @@
+export type NostrEvent = {
+    id: string;
+    pubkey: string;
+    created_at: number;
+    kind: number;
+    tags: string[][];
+};
+
+const dTag = (event: NostrEvent): string | undefined =>
+    event.tags.find(tag => tag[0] === "d")?.[1];
+
+const addressMatches = (ride: NostrEvent, address: string): boolean => {
+    const [kind, pubkey, ...identifierParts] = address.split(":");
+    const identifier = identifierParts.join(":");
+    return (
+        kind === String(ride.kind) &&
+        pubkey === ride.pubkey &&
+        identifier === dTag(ride)
+    );
+};
+
+export const isDeletedBy = (
+    ride: NostrEvent,
+    deletion: NostrEvent,
+): boolean => {
+    if (deletion.kind !== 5 || deletion.pubkey !== ride.pubkey) return false;
+
+    return deletion.tags.some(tag => {
+        if (tag[0] === "e") return tag[1] === ride.id;
+        if (tag[0] === "a") {
+            return (
+                deletion.created_at >= ride.created_at &&
+                addressMatches(ride, tag[1] ?? "")
+            );
+        }
+        return false;
+    });
+};
+
+export const isDeleted = (
+    ride: NostrEvent,
+    deletions: NostrEvent[],
+): boolean => deletions.some(deletion => isDeletedBy(ride, deletion));

--- a/nostr/fetch_hitchhiking_events/src/index.ts
+++ b/nostr/fetch_hitchhiking_events/src/index.ts
@@ -19,6 +19,7 @@ import { writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { config as loadEnv } from "dotenv";
+import { isDeleted, NostrEvent } from "./deletions.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -129,12 +130,37 @@ for (const relay of relayUrls) {
     }
 }
 
-// Build final array sorted by created_at, with relay info attached
-const allPosts = Array.from(eventMap.values())
+// NIP-09 deletion requests are intentionally fetched without a time cutoff.
+// A relay may already have removed the referenced ride, and retaining every
+// small kind-5 tombstone prevents a later full import from resurrecting it.
+const deletionMap = new Map<string, NostrEvent>();
+for (const relay of relayUrls) {
+    try {
+        const deletions = await fetcher.fetchAllEvents(
+            [relay],
+            { kinds: [5] },
+            {},
+            { sort: true },
+        );
+        for (const deletion of deletions) {
+            deletionMap.set(deletion.id, deletion as NostrEvent);
+        }
+    } catch (e) {
+        console.error(`Failed to fetch deletion requests from ${relay}:`, e);
+    }
+}
+const deletions = Array.from(deletionMap.values());
+console.log(deletions.length, "unique NIP-09 deletion requests fetched");
+
+// Build final array sorted by created_at, with relay info attached, then apply
+// author-authenticated event-id and address tombstones.
+const fetchedPosts = Array.from(eventMap.values())
     .sort((a, b) => a.event.created_at - b.event.created_at)
     .map(({ event, relays }) => ({ ...event, _relays: relays }));
+const allPosts = fetchedPosts.filter(post => !isDeleted(post as NostrEvent, deletions));
 
 console.log(allPosts.length, "unique posts fetched across", relayUrls.length, "relays");
+console.log(fetchedPosts.length - allPosts.length, "posts removed by NIP-09 requests");
 
 // Apply the optional source filter. A ride's origin app is stored in the
 // JSON-encoded "content" under "source"; relays cannot filter on content, so


### PR DESCRIPTION
Closes the design question in #38. `expiration=0` (NIP-40) is an already-expired event a relay may drop on arrival — not a durable deletion signal, and relays that don't advertise NIP-40 aren't even supposed to receive it.

Proposes a NIP-09 kind-5 deletion request instead, signed by the ride's author. Since a kind-36820 ride is an addressable event, the required `a` tag (kind + author pubkey + `d` value) covers every version published up to the request time; a recommended `e` tag names the current event ID for readers that only match by ID; `k` declares the deleted kind.

Also updates the bundled TypeScript example reader (`nostr/fetch_hitchhiking_events`) to fetch all kind-5 tombstones and enforce that a delete only applies when it's signed by the same key as the ride it targets and addresses/IDs it correctly — so a forged or mismatched delete can't be used to wipe someone else's ride, and an older deletion can't erase a later republish.

**Verification:** 7/7 new deletion tests pass (address match, exact ID match, clock-skewed exact ID, wrong signer, wrong embedded signer, later republish not deleted, unrelated ID untouched); TypeScript compiles; a live read against the current relay fetched 83 ride events and 0 deletion requests without error.

Documents plainly that this cannot guarantee erasure from every external copy that already fetched the ride — only that compliant readers of this format will honor a deletion request going forward.

Opened as draft for maintainer review, per project convention.